### PR TITLE
fix: provide a discord.Member object instead of string to slash commands

### DIFF
--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -53,6 +53,13 @@ async def on_ready():
 
     bot.add_view(DonateCommandView())  # register view for persistent listening
 
+    # try to force sync commands
+    # calling an outdated command seems to force a sync
+    await bot.sync_commands(
+        commands=bot.commands,
+        force=True,
+    )
+
     try:
         os.environ['DAILY_TASKS']
     except KeyError:
@@ -181,7 +188,7 @@ async def channel(ctx: discord.ApplicationContext,
 )
 async def donate_command(ctx: discord.ApplicationContext,
                          user: Option(
-                             input_type=discord.Member,
+                             discord.Member,
                              description=user_mention_desc,
                              required=False)
                          ):
@@ -210,7 +217,7 @@ async def donate_command(ctx: discord.ApplicationContext,
 )
 async def random_command(ctx: discord.ApplicationContext,
                          user: Option(
-                             input_type=discord.Member,
+                             discord.Member,
                              description=user_mention_desc,
                              required=False)
                          ):
@@ -258,7 +265,7 @@ async def random_command(ctx: discord.ApplicationContext,
 )
 async def docs_command(ctx: discord.ApplicationContext,
                        user: Option(
-                           input_type=discord.Member,
+                           discord.Member,
                            description=user_mention_desc,
                            required=False)
                        ):
@@ -300,7 +307,7 @@ async def docs_command(ctx: discord.ApplicationContext,
 )
 async def refund_command(ctx: discord.ApplicationContext,
                          user: Option(
-                             input_type=discord.Member,
+                             discord.Member,
                              description=user_mention_desc,
                              required=False)
                          ):


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Using `input_type` provides a string instead of User/Member object. See: https://github.com/Pycord-Development/pycord/issues/2428

Additionally, "try" to force syncing commands when the bot starts.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
